### PR TITLE
better file handling + m4a support

### DIFF
--- a/backend/src/voilib/collection/feed.py
+++ b/backend/src/voilib/collection/feed.py
@@ -10,6 +10,7 @@ don't interact with the database.
 import logging
 import typing
 from datetime import datetime
+import re
 
 import dateutil.parser
 import requests  # type: ignore
@@ -54,6 +55,8 @@ def _episode_duration(duration: typing.Optional[str]) -> int:
         return int(hours) * 3600 + int(minutes) * 60 + int(secs)
     return int(duration)
 
+def _episode_filename_from_url(url: str) -> str:
+    return re.match("\/([^\/]+)$", url)
 
 def _episode_guid(guid: typing.Union[dict, str]) -> str:
     return guid["#text"] if isinstance(guid, dict) else guid
@@ -94,12 +97,14 @@ def read_episodes(channel: models.Channel) -> list[models.Episode]:
         if ep.get("itunes:episodeType", None) not in ["bonus", "trailer"]:
             title = ep.get("title", None)
             if title:
+                url=ep["enclosure"]["@url"]
                 episode = models.Episode(
                     title=title,
+                    filename=_episode_filename_from_url(url),
                     guid=_episode_guid(ep["guid"]),
                     description=ep.get("description", "") or "",
                     date=_episode_date(ep["pubDate"]),
-                    url=ep["enclosure"]["@url"],
+                    url=url,
                     episode=int(ep.get("itunes:episode", -1)),
                     season=int(ep.get("itunes:season", -1)),
                     duration=_episode_duration(ep.get("itunes:duration", None)),

--- a/backend/src/voilib/collection/local.py
+++ b/backend/src/voilib/collection/local.py
@@ -25,7 +25,7 @@ def read_local_channel(info: dict) -> models.Channel:
         kind=models.ChannelKind.local.value,
         description=info.get("description", ""),
         language=info["language"],
-        url="",
+        url=info["folder"],
         feed="",
         local_folder=info["folder"],
         image=info.get("image", ""),
@@ -42,11 +42,13 @@ def read_local_episodes(channel: models.Channel) -> list[models.Episode]:
     channel_folder = storage.LOCAL_CHANNELS_PATH / channel.local_folder
     mp3_files = list(channel_folder.glob("*.mp3"))
     wav_files = list(channel_folder.glob("*.wav"))
+    m4a_files = list(channel_folder.glob("*.m4a"))
     episodes: list[models.Episode] = []
-    for ep in mp3_files + wav_files:
+    for ep in mp3_files + wav_files + m4a_files:
         uri = f"{channel.local_folder}/{ep.name}"
         episode = models.Episode(
             title=ep.name,
+            filename=ep.name,
             guid=uri,
             description="",
             # take date from audio file metadata

--- a/backend/src/voilib/models/media.py
+++ b/backend/src/voilib/models/media.py
@@ -63,6 +63,7 @@ class Episode(base.CoreModel):
         ondelete=ormar.ReferentialAction.CASCADE,
     )
     title: str = ormar.String(max_length=250)  # type: ignore
+    filename: str = ormar.String(max_length=250) # type: ignore
     description: str = ormar.Text()  # type: ignore
     date = ormar.DateTime(timezone=True, nullable=True)
     guid = ormar.Text()  # episode guid at origin

--- a/backend/src/voilib/tests/test_storage.py
+++ b/backend/src/voilib/tests/test_storage.py
@@ -5,12 +5,12 @@ from voilib import storage
 
 
 async def test_episodes(channel) -> None:  # type: ignore
-    assert "kaizen" in str(storage.channel_path(channel))
+    assert "kaizen" in storage.MEDIA_PATH / channel.title
     assert await channel.episodes.count() == 5
     ep = await channel.episodes.first()
     trfile = await storage.transcription_file(ep)
     assert ".csv" in str(trfile)
-    epfile = await storage.episode_file(ep)
+    epfile = storage.MEDIA_PATH / channel.title / ep.filename
     assert ".mp3" in str(epfile)
     assert trfile.stem == epfile.stem
     assert (await storage.download_episode(ep)).exists()


### PR DESCRIPTION
This PR contains a few things, which all felt disparate when I started, but were all connected to the local file handing in one way or another.

- M4A support. I have a podcast that is in this format, and it is just completely ignored by voilib. FastWhisper seems to support it so I added it as a supported format.
- File handling improvement
    - I could not import my local files, which was because voilib expects the names to be the strange slugified concatenation of title and url. Both for the channel name and the episode name. I see no real benefit of this, each episode of a specific podcast should be a unique filename.
    - Filename is now an entry on the episodes table / class. This is taken as the filename itself for local files, and calculated as the download file from the rss feed via regex

None of this is tested yet 😁 I'll get to that soon™️ Just wanted to get this up so it can be seen asap 👍 